### PR TITLE
Fix URL and Notebook outputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,29 +37,40 @@ def stats():
 def about():
     return render_template('about.html')
 
-
-### DATABASE ROUTES ### 
-# @app.route('/<attb>/data')
+# @app.route('/<attb>/active')
 # def db_data(attb):
 
-#     db_data = mongo.db.fires.find({'IsActive':attb}, {'_id': False})
-#     print('this route was pinged')
+#     if str(attb) == "true" or "True" or 1:
+#         db_data = list(mongo.db.fires.find({'IsActive': True}, {'_id': False}))
+#         print('this route True value was pinged')
+
+#     elif str(attb) == "false" or "False" or 0:
+#         db_data = list(mongo.db.fires.find({'IsActive': False}, {'_id': False}))
+#         print('this route False value was pinged')
+
+#     else:
+#         print("Not a Valid URL")
+#         return
+    
 #     parsed = [x for x in db_data]
-#     print('parsed: ', parsed)
+    
+#     # print('parsed: ', parsed)
+#     # print(type(parsed))
 #     return jsonify(parsed)
 
-@app.route('/<attb>/active')
-def db_data(attb):
+@app.route('/active/fires')
+def activeFires():
 
-    db_data = list(mongo.db.fires.find({'IsActive': bool(attb)},{'_id': False}))
-    print('this route was pinged')
-    print('db_data is below this line')
-    print(db_data)
+    db_data = list(mongo.db.fires.find({'IsActive': True}, {'_id': False}))
     parsed = [x for x in db_data]
-    print('parsed: ', parsed)
-    print(type(parsed))
     return jsonify(parsed)
+    
+@app.route('/inactive/fires')
+def inactiveFires():
 
+    db_data = list(mongo.db.fires.find({'IsActive': False}, {'_id': False}))
+    parsed = [x for x in db_data]
+    return jsonify(parsed)
 
 
 # Debugger

--- a/jupyter/starting-analysis.ipynb
+++ b/jupyter/starting-analysis.ipynb
@@ -370,7 +370,7 @@
     "json_data = dumps(final_data, indent = 4) \n",
     "   \n",
     "# Writing data to file data.json - Easy for JavaScript Access\n",
-    "with open('../app/data/fires.json', 'w') as file:\n",
+    "with open('../data/fires.json', 'w') as file:\n",
     "    file.write(json_data)"
    ]
   }


### PR DESCRIPTION
Since app was reversed from its packaged state, the output to ..app/data/ was no longer a valid path for the jupyter notebook. This has been fixed.

The URL route was not accepting the argument as a boolean value. After hours of fiddling, I have created two separate routs to mimic the functionality, but would still like to investigate why the original implementation was not working.